### PR TITLE
Update PowerSpinner to 1.2.3 and Landscapist to 1.5.2

### DIFF
--- a/buildSrc/src/main/kotlin/com/skydoves/orchestra/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/skydoves/orchestra/Dependencies.kt
@@ -19,9 +19,9 @@ object Versions {
 
   internal const val BALLOON = "1.4.5"
   internal const val COLORPICKERVIEW = "2.2.4"
-  internal const val POWERSPINNER = "1.2.1"
+  internal const val POWERSPINNER = "1.2.3"
 
-  internal const val LANDSCAPIST = "1.5.1"
+  internal const val LANDSCAPIST = "1.5.2"
 }
 
 object Dependencies {


### PR DESCRIPTION
## Overview
Update PowerSpinner to 1.2.3 and Landscapist to 1.5.2.